### PR TITLE
fix: config file for FSL FWE p<0.005, use versions instead of version

### DIFF
--- a/fsl_FWE_p005/config.json
+++ b/fsl_FWE_p005/config.json
@@ -3,5 +3,5 @@
 "software": "fsl",
 "ground_truth": ["voxel_FWE_p_05/nidm.ttl"],
 "inclusive": true,
-"version": "1.2.0"
+"versions": ["1.2.0"]
 }


### PR DESCRIPTION
This is a fix to `fsl_FWE_p005/config.json` to use "versions" instead of "version". This key has been changed in 889bffac6ae933d56793716c356b3245874e1ab6 to allow for testing against more than one version of NIDM-Results.

This fix is implemented in its own PR, so that we can merge this now and run the tests on the NIDM-Resuts exporter for FSL. But https://github.com/incf-nidash/nidmresults-examples/pull/24 will also have to be updated accordingly.
