### PR TITLE
AFNI group level t-test run on DS0011 data

### DIFF
--- a/afni_t_test/Clust_mask+tlrc.BRIK.gz
+++ b/afni_t_test/Clust_mask+tlrc.BRIK.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5ff7197a9f9ee0287735f3ae12583cb40b41f2e6dcc6a51082961e21e988835
+size 2411

--- a/afni_t_test/Clust_mask+tlrc.HEAD
+++ b/afni_t_test/Clust_mask+tlrc.HEAD
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91bf12e9abe7d90b7b21eedb9272ccfed89a47e33941bf9cb336ed7f8655c575
+size 2752

--- a/afni_t_test/README.md
+++ b/afni_t_test/README.md
@@ -1,7 +1,11 @@
-AFNI 2nd-level results from task001_run001 of the OpenfMRI ds000006 living-nonliving decision experiment, used for exporting uncorrected p=0.001 NIDM-results with a one-sample t-test.
+AFNI t-test with subjects 1-14, tone counting task, taken from OpenfMRI DS000011 classification learning and tone counting experiment. 
 
-Pre-processing and 1st-level analyses were conducted in SPM. 
+This variant is a group-level t-test.  
 
-Contrasts used: mr vs plain switch vs nonswitch switch vs nonswitch mr only switch vs nonswitch plain only
+Contrast used:
+tone counting vs. baseline
 
-For task001_run001 subjects had to complete 64 trials, where each trial consisted of a word being presented to the subject in either plain or mirror-reversed text for which they had to respond as to whether the word named a living or nonliving entity by pressing the corresponding button. Words were chosen from a list permuted across participants and presented pseudorandomly such that the run included 32 plain and 32 mirror-reversed words for each subject. Subjects were not given feedback on their responses. The response window for each trial was 3.25 seconds, with a variable interstimulus interval of mean 6.28 seconds.
+For a description of the task, see:
+
+https://openfmri.org/dataset/ds000011/
+

--- a/afni_t_test/TT_N27+tlrc.BRIK.gz
+++ b/afni_t_test/TT_N27+tlrc.BRIK.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6bddefb1e35d2e3889f5fbb1a7341b6c6ee95916489978b0de964b3bfd7f6b07
+size 1353925

--- a/afni_t_test/TT_N27+tlrc.HEAD
+++ b/afni_t_test/TT_N27+tlrc.HEAD
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72dca066685cfb3b66f57ea9db1115dc4947a760f8a61845cfad8223de918caa
+size 11447

--- a/afni_t_test/batch.sh
+++ b/afni_t_test/batch.sh
@@ -1,18 +1,1 @@
-3dttest++ -prefix ttest++_result       \
-          -setA setA                   \
-             01 "Sub01_con0001.nii[0]" \
-             02 "Sub02_con0001.nii[0]" \
-             03 "Sub03_con0001.nii[0]" \
-             04 "Sub04_con0001.nii[0]" \
-             05 "Sub05_con0001.nii[0]" \
-             06 "Sub06_con0001.nii[0]" \
-             07 "Sub07_con0001.nii[0]" \
-             08 "Sub08_con0001.nii[0]" \
-             09 "Sub09_con0001.nii[0]" \
-             10 "Sub10_con0001.nii[0]" \
-             11 "Sub11_con0001.nii[0]" \
-             12 "Sub12_con0001.nii[0]" \
-             13 "Sub13_con0001.nii[0]" \
-             14 "Sub14_con0001.nii[0]" 
-
- 3dclust -1Dformat -nosum -1dindex 0 -1tindex 1 -2thresh -4.221 4.221 -dxyz=1 1.01 2 ./ttest++_result+tlrc.HEAD
+3dclust -1Dformat -nosum -1dindex 1 -1tindex 1 -2thresh -4.221 4.221 -dxyz=1 -savemask Clust_mask 1.01 2 ./afni_t_test/ttest++_result+tlrc.HEAD

--- a/afni_t_test/stats.sub_001+tlrc.BRIK
+++ b/afni_t_test/stats.sub_001+tlrc.BRIK
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37ceaf7e9d8564d8529d25f3f3538965854424ccef5cda1a5e533729529eb2ae
+size 4838400

--- a/afni_t_test/stats.sub_001+tlrc.HEAD
+++ b/afni_t_test/stats.sub_001+tlrc.HEAD
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26c19752bf4d8016b4e3bbdc0551cb82dedbe771d1f87cd3a6633c27a827c352
+size 54129

--- a/afni_t_test/stats.sub_002+tlrc.BRIK
+++ b/afni_t_test/stats.sub_002+tlrc.BRIK
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9bfd28da5500187b3df8cc9bd2e086b03461b84fca453ef73d5c284be1e1df39
+size 4838400

--- a/afni_t_test/stats.sub_002+tlrc.HEAD
+++ b/afni_t_test/stats.sub_002+tlrc.HEAD
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e01aedbf739c892dbea1b9d0d381a2646dd21676c408d5f18fa5f1f57de138a3
+size 54764

--- a/afni_t_test/stats.sub_003+tlrc.BRIK
+++ b/afni_t_test/stats.sub_003+tlrc.BRIK
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83c3910e04f08b0d45990fe82e83a63de9a8382359baeb0a2c324044c22019a1
+size 4838400

--- a/afni_t_test/stats.sub_003+tlrc.HEAD
+++ b/afni_t_test/stats.sub_003+tlrc.HEAD
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e63942e17fd7eef59d5eb40260dd3fc0a510e0eaed1fdfc582b4c118b206f7d7
+size 54565

--- a/afni_t_test/stats.sub_004+tlrc.BRIK
+++ b/afni_t_test/stats.sub_004+tlrc.BRIK
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6a3f3872b944757ae87dc35d29af86a54e326c9b75d451977d3a79ae354c08a
+size 4838400

--- a/afni_t_test/stats.sub_004+tlrc.HEAD
+++ b/afni_t_test/stats.sub_004+tlrc.HEAD
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b70237a4e99e8b7573890915b62c1ef58e1ee0dcd44db0e0958211e3d543a4cc
+size 55212

--- a/afni_t_test/stats.sub_005+tlrc.BRIK
+++ b/afni_t_test/stats.sub_005+tlrc.BRIK
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d73ad6ba5b0132e9e838f14a6883941cf5c46d6029e0cb7921f7c9ef18d6480
+size 4838400

--- a/afni_t_test/stats.sub_005+tlrc.HEAD
+++ b/afni_t_test/stats.sub_005+tlrc.HEAD
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e8fd80e847982b1c564c60cfec019963106a751065e130a5326d464a7ee6f5a
+size 56454

--- a/afni_t_test/stats.sub_006+tlrc.BRIK
+++ b/afni_t_test/stats.sub_006+tlrc.BRIK
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc323a6dff5eb20d39645241e58d00a84dfb18dc067501738a3149765903035d
+size 4838400

--- a/afni_t_test/stats.sub_006+tlrc.HEAD
+++ b/afni_t_test/stats.sub_006+tlrc.HEAD
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9bfcdceedb82b4ade2d6312df1a8cb40fcfaf7e4ff109e2644e25d5bbd24757
+size 54677

--- a/afni_t_test/stats.sub_007+tlrc.BRIK
+++ b/afni_t_test/stats.sub_007+tlrc.BRIK
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:996cb115e4f1d4d53aa96a4421aebd89e45a2498647112ddb705c13145f54994
+size 4838400

--- a/afni_t_test/stats.sub_007+tlrc.HEAD
+++ b/afni_t_test/stats.sub_007+tlrc.HEAD
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e034c09b58e0d23e040b4f69d32f2fa546806cb816b5ba2b4b0b994d27b3d6fb
+size 55942

--- a/afni_t_test/stats.sub_008+tlrc.BRIK
+++ b/afni_t_test/stats.sub_008+tlrc.BRIK
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17e68086903d9e92687064f765e38d01dc53ca38d4496bc4921481e22729878c
+size 4838400

--- a/afni_t_test/stats.sub_008+tlrc.HEAD
+++ b/afni_t_test/stats.sub_008+tlrc.HEAD
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0e44fa75b7da7c24348a32fc95bbb6a4d2b80138aa21b6863185ead5612cc57
+size 55267

--- a/afni_t_test/stats.sub_009+tlrc.BRIK
+++ b/afni_t_test/stats.sub_009+tlrc.BRIK
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18c0fd7a9a20a3517abee0b914d581c654c2e134b881c53a46af3951fb035938
+size 4838400

--- a/afni_t_test/stats.sub_009+tlrc.HEAD
+++ b/afni_t_test/stats.sub_009+tlrc.HEAD
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5e936137a99230c800bc34a7a69d4d6f260f5f6a53d03b8a2b4646493db2c8f8
+size 54251

--- a/afni_t_test/stats.sub_010+tlrc.BRIK
+++ b/afni_t_test/stats.sub_010+tlrc.BRIK
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc212b9cba93f53f1feebd8b13e2643a9f0dcb4950f902cf59efdffed8345309
+size 4838400

--- a/afni_t_test/stats.sub_010+tlrc.HEAD
+++ b/afni_t_test/stats.sub_010+tlrc.HEAD
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34842314d56c9a042381cca14dbd5647b1f622a467533a736d6ea53b939d86e4
+size 54870

--- a/afni_t_test/stats.sub_011+tlrc.BRIK
+++ b/afni_t_test/stats.sub_011+tlrc.BRIK
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8a290eba7db86a053ab7b62bae9d89c6963a2883278f6ee61723224a6607027
+size 4838400

--- a/afni_t_test/stats.sub_011+tlrc.HEAD
+++ b/afni_t_test/stats.sub_011+tlrc.HEAD
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f993b869cce23fcff35a8bfe5be3d4a29f7d9d0310361d97108c69a04cdbcd27
+size 56948

--- a/afni_t_test/stats.sub_012+tlrc.BRIK
+++ b/afni_t_test/stats.sub_012+tlrc.BRIK
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eeebc100df1b6856a8b61ad727fbabdbe2d67e422716cdc45adea7068d8bc4d4
+size 4838400

--- a/afni_t_test/stats.sub_012+tlrc.HEAD
+++ b/afni_t_test/stats.sub_012+tlrc.HEAD
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9bdee71df891fff555ec8d139b9470c32acc37751e83460818496a3f06dae9f
+size 55720

--- a/afni_t_test/stats.sub_013+tlrc.BRIK
+++ b/afni_t_test/stats.sub_013+tlrc.BRIK
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6a8c5a86d8d0eba8d81b1d6e12f3388835d78812dc7a45552961cb553b059c8
+size 4838400

--- a/afni_t_test/stats.sub_013+tlrc.HEAD
+++ b/afni_t_test/stats.sub_013+tlrc.HEAD
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:72776d012b79c7ad20615042622219183b1aef2f2be305c93c9bbe525d3785d0
+size 55390

--- a/afni_t_test/stats.sub_014+tlrc.BRIK
+++ b/afni_t_test/stats.sub_014+tlrc.BRIK
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97a1a46ef26880603f565ca1a98e66faaa68794e7fda8d202ebe68b5a0cb762b
+size 4838400

--- a/afni_t_test/stats.sub_014+tlrc.HEAD
+++ b/afni_t_test/stats.sub_014+tlrc.HEAD
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45d7bab730c80c667a6262af7d8efb7352e633870660f982b384763409fd7d9a
+size 55824

--- a/afni_t_test/ttest++_result+tlrc.BRIK
+++ b/afni_t_test/ttest++_result+tlrc.BRIK
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:526f9c5d3ddecd4cf6ccb29d67209513f1d8d1ab4baeea86dd65792edc6af138
-size 4743160
+oid sha256:e86506572857d4938bfeec21517e11df5c741f298281e8b106ce3c3c8fdec4e1
+size 1382400

--- a/afni_t_test/ttest++_result+tlrc.HEAD
+++ b/afni_t_test/ttest++_result+tlrc.HEAD
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c539080d3e1928fcd15218ea9662b1fb6c32bd9e1e28a38144b157a2fe874611
-size 4825
+oid sha256:cdfc3ef3499a8ab0de31d5d767e7d99b05a29d14cd31b36b2d8424c5f95bea48
+size 4349

--- a/afni_t_test/ttest_script
+++ b/afni_t_test/ttest_script
@@ -1,0 +1,18 @@
+3dttest++ -prefix ttest++_result       \
+          -setA setA                   \
+             01 "stats.sub_001+tlrc.HEAD[1]" \
+             02 "stats.sub_002+tlrc.HEAD[1]" \
+             03 "stats.sub_003+tlrc.HEAD[1]" \
+             04 "stats.sub_004+tlrc.HEAD[1]" \
+             05 "stats.sub_005+tlrc.HEAD[1]" \
+             06 "stats.sub_006+tlrc.HEAD[1]" \
+             07 "stats.sub_007+tlrc.HEAD[1]" \
+             08 "stats.sub_008+tlrc.HEAD[1]" \
+             09 "stats.sub_009+tlrc.HEAD[1]" \
+             10 "stats.sub_010+tlrc.HEAD[1]" \
+             11 "stats.sub_011+tlrc.HEAD[1]" \
+             12 "stats.sub_012+tlrc.HEAD[1]" \
+             13 "stats.sub_013+tlrc.HEAD[1]" \
+             14 "stats.sub_014+tlrc.HEAD[1]" 
+        
+


### PR DESCRIPTION
This pull request updates the AFNI group level t-test with results from DS0011 data. (Previously this test had only been run on DS0006 data). 
