### PR TITLE
corrected error in README file

### DIFF
--- a/afni_f_test/README.md
+++ b/afni_f_test/README.md
@@ -1,4 +1,4 @@
-AFNI single subject t-test results from subject 01, tone counting task, taken from OpenfMRI DS000011 classification learning and tone counting experiment. 
+AFNI single subject F-test results from subject 01, tone counting task, taken from OpenfMRI DS000011 classification learning and tone counting experiment. 
 
 This is the default single-subject F-test, with p<0.001 uncorrected. 
 


### PR DESCRIPTION
This pull request corrects an error in the README file for the AFNI F-test, so that line one now reads as:
"AFNI single subject F-test results from subject 01"
rather than:
AFNI single subject t-test results from subject 01"
