### PR TITLE
spm_non_sphericity_inputs

### DIFF
--- a/spm_non_sphericity/batch.m
+++ b/spm_non_sphericity/batch.m
@@ -1,6 +1,6 @@
 %-----------------------------------------------------------------------
-% Job saved on 08-Dec-2015 10:52:04 by cfg_util (rev $Rev: 6460 $)
-% spm SPM - SPM12 (6470)
+% Job saved on 04-Jul-2016 11:13:21 by cfg_util (rev $Rev: 6460 $)
+% spm SPM - SPM12 (6685)
 % cfg_basicio BasicIO - Unknown
 %-----------------------------------------------------------------------
 matlabbatch{1}.spm.stats.factorial_design.dir = {'/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Group/Informed'};
@@ -13,58 +13,58 @@ matlabbatch{1}.spm.stats.factorial_design.des.fd.fact.ancova = 0;
 matlabbatch{1}.spm.stats.factorial_design.des.fd.icell(1).levels = 1;
 %%
 matlabbatch{1}.spm.stats.factorial_design.des.fd.icell(1).scans = {
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub01/CanonicalHRF/con_0001.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub02/CanonicalHRF/con_0001.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub03/CanonicalHRF/con_0001.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub04/CanonicalHRF/con_0001.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub05/CanonicalHRF/con_0001.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub06/CanonicalHRF/con_0001.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub07/CanonicalHRF/con_0001.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub08/CanonicalHRF/con_0001.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub09/CanonicalHRF/con_0001.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub10/CanonicalHRF/con_0001.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub11/CanonicalHRF/con_0001.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub12/CanonicalHRF/con_0001.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub13/CanonicalHRF/con_0001.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub14/CanonicalHRF/con_0001.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub01_con0001.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub02_con0001.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub03_con0001.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub04_con0001.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub05_con0001.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub06_con0001.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub07_con0001.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub08_con0001.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub09_con0001.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub10_con0001.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub11_con0001.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub12_con0001.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub13_con0001.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub14_con0001.nii,1'
                                                                    };
 %%
 matlabbatch{1}.spm.stats.factorial_design.des.fd.icell(2).levels = 2;
 %%
 matlabbatch{1}.spm.stats.factorial_design.des.fd.icell(2).scans = {
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub01/CanonicalHRF/con_0005.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub02/CanonicalHRF/con_0005.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub03/CanonicalHRF/con_0005.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub04/CanonicalHRF/con_0005.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub05/CanonicalHRF/con_0005.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub06/CanonicalHRF/con_0005.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub07/CanonicalHRF/con_0005.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub08/CanonicalHRF/con_0005.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub09/CanonicalHRF/con_0005.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub10/CanonicalHRF/con_0005.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub11/CanonicalHRF/con_0005.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub12/CanonicalHRF/con_0005.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub13/CanonicalHRF/con_0005.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub14/CanonicalHRF/con_0005.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub01_con0005.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub02_con0005.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub03_con0005.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub04_con0005.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub05_con0005.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub06_con0005.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub07_con0005.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub08_con0005.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub09_con0005.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub10_con0005.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub11_con0005.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub12_con0005.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub13_con0005.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub14_con0005.nii,1'
                                                                    };
 %%
 matlabbatch{1}.spm.stats.factorial_design.des.fd.icell(3).levels = 3;
 %%
 matlabbatch{1}.spm.stats.factorial_design.des.fd.icell(3).scans = {
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub01/CanonicalHRF/con_0009.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub02/CanonicalHRF/con_0009.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub03/CanonicalHRF/con_0009.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub04/CanonicalHRF/con_0009.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub05/CanonicalHRF/con_0009.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub06/CanonicalHRF/con_0009.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub07/CanonicalHRF/con_0009.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub08/CanonicalHRF/con_0009.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub09/CanonicalHRF/con_0009.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub10/CanonicalHRF/con_0009.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub11/CanonicalHRF/con_0009.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub12/CanonicalHRF/con_0009.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub13/CanonicalHRF/con_0009.nii,1'
-                                                                   '/storage/essicd/data/NIDM-Ex/Testing/ds000006/RESULTS/Sub14/CanonicalHRF/con_0009.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub01_con0009.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub02_con0009.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub03_con0009.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub04_con0009.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub05_con0009.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub06_con0009.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub07_con0009.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub08_con0009.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub09_con0009.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub10_con0009.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub11_con0009.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub12_con0009.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub13_con0009.nii,1'
+                                                                   '/storage/essicd/data/NIDM-Ex/BIDS_Data/RESULTS/TEST/nidmresults-examples/spm_non_sphericity/input/sub14_con0009.nii,1'
                                                                    };
 %%
 matlabbatch{1}.spm.stats.factorial_design.des.fd.contrasts = 1;
@@ -90,6 +90,7 @@ matlabbatch{4}.spm.stats.results.conspec.contrasts = 1;
 matlabbatch{4}.spm.stats.results.conspec.threshdesc = 'none';
 matlabbatch{4}.spm.stats.results.conspec.thresh = 0.001;
 matlabbatch{4}.spm.stats.results.conspec.extent = 0;
+matlabbatch{4}.spm.stats.results.conspec.conjunction = 1;
 matlabbatch{4}.spm.stats.results.conspec.mask.none = 1;
 matlabbatch{4}.spm.stats.results.units = 1;
 matlabbatch{4}.spm.stats.results.print = 'pdf';

--- a/spm_non_sphericity/input/sub01_con0001.nii
+++ b/spm_non_sphericity/input/sub01_con0001.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ef8d2a9231a17b529a674ce00694f37507585e457713c0333b78726676c5c12
+size 2371932

--- a/spm_non_sphericity/input/sub01_con0005.nii
+++ b/spm_non_sphericity/input/sub01_con0005.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bdd49c03a21b0e96cdaaa6d216ac09f80b362b95ad195e801fd16cfa1f558067
+size 2371932

--- a/spm_non_sphericity/input/sub01_con0009.nii
+++ b/spm_non_sphericity/input/sub01_con0009.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4550cb0335fb45a4caa6dcb56ed7df48a7c86b3a1a53b9178f52c24e54a90760
+size 2371932

--- a/spm_non_sphericity/input/sub02_con0001.nii
+++ b/spm_non_sphericity/input/sub02_con0001.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:210570941d18167e0726754c1a54e77f71d88a519eaf26b0535dc56f56764c36
+size 2371932

--- a/spm_non_sphericity/input/sub02_con0005.nii
+++ b/spm_non_sphericity/input/sub02_con0005.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edfcb297b3cdfb0d2ac7b9b784610d2f0ff49b18aafb4afff18b2d7fd3bf04f3
+size 2371932

--- a/spm_non_sphericity/input/sub02_con0009.nii
+++ b/spm_non_sphericity/input/sub02_con0009.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6899d32879db46916685fe1b4e9f4c2bfd298b1f21b3807bcc8a482c8746ff68
+size 2371932

--- a/spm_non_sphericity/input/sub03_con0001.nii
+++ b/spm_non_sphericity/input/sub03_con0001.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e03daecd4a80989035c917da1142aec71d84a983a9a4122f4bf232cfbbc1e99a
+size 2371932

--- a/spm_non_sphericity/input/sub03_con0005.nii
+++ b/spm_non_sphericity/input/sub03_con0005.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:679da830bc2dd46492adec3eb03f552b7cb4e16a5f484972d9ca606f86354a8c
+size 2371932

--- a/spm_non_sphericity/input/sub03_con0009.nii
+++ b/spm_non_sphericity/input/sub03_con0009.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f729f2748a5ab70d0d9286d4ab7fd8deb1af2b80fa207f7a12038873d34d0ed
+size 2371932

--- a/spm_non_sphericity/input/sub04_con0001.nii
+++ b/spm_non_sphericity/input/sub04_con0001.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb55e8eedb4984bea1dead2d4002bfff733efd0302d8c05f83b8a98f3d70a743
+size 2371932

--- a/spm_non_sphericity/input/sub04_con0005.nii
+++ b/spm_non_sphericity/input/sub04_con0005.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31eddc17c56042f9849338fdf8a6be584458be7d09c282ec9a3b641f5d67ab30
+size 2371932

--- a/spm_non_sphericity/input/sub04_con0009.nii
+++ b/spm_non_sphericity/input/sub04_con0009.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53a19065b9e12a1e9015b80c77f1eec72f3b4975bb6000503f5cef6f4e798bd0
+size 2371932

--- a/spm_non_sphericity/input/sub05_con0001.nii
+++ b/spm_non_sphericity/input/sub05_con0001.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b7b587e47dd0fed9563fb7fb3f539f0d30ecaba37db5c985010b9f822792b6fd
+size 2371932

--- a/spm_non_sphericity/input/sub05_con0005.nii
+++ b/spm_non_sphericity/input/sub05_con0005.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e79520847f3dd8fa0e78853befa905ca45f1ad29c30052e67322481fc19eff23
+size 2371932

--- a/spm_non_sphericity/input/sub05_con0009.nii
+++ b/spm_non_sphericity/input/sub05_con0009.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abbe8fb0f90c8bf7f507fbc68c6a460c848cc61fd320af9c35bcb9c944cdec24
+size 2371932

--- a/spm_non_sphericity/input/sub06_con0001.nii
+++ b/spm_non_sphericity/input/sub06_con0001.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50f3f922b4094f9bdecae8b5ecbbe8a67cb5ce02ee3fef08a1397ade11e6eb20
+size 2371932

--- a/spm_non_sphericity/input/sub06_con0005.nii
+++ b/spm_non_sphericity/input/sub06_con0005.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6cd1dc38c4d0444936c300b66f6c1e1561c7f448a546a990cf3c2e707e7622f7
+size 2371932

--- a/spm_non_sphericity/input/sub06_con0009.nii
+++ b/spm_non_sphericity/input/sub06_con0009.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30e4a0b298e630365e8b289fd8d2e7ed7e415528e6141daf729a65429f2b1fe1
+size 2371932

--- a/spm_non_sphericity/input/sub07_con0001.nii
+++ b/spm_non_sphericity/input/sub07_con0001.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f602c04e069b7757d3165a241912f2d325693a6b5708f556d4afdc07d47ea07
+size 2371932

--- a/spm_non_sphericity/input/sub07_con0005.nii
+++ b/spm_non_sphericity/input/sub07_con0005.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9eef5538d713445bb90ac8d31bc973bde46d6de8db59ad6395541eb74b38f1f6
+size 2371932

--- a/spm_non_sphericity/input/sub07_con0009.nii
+++ b/spm_non_sphericity/input/sub07_con0009.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:193d10e9b9e3e7bee11c75f59735ace744c96b95667bcd4fc0423122879a0716
+size 2371932

--- a/spm_non_sphericity/input/sub08_con0001.nii
+++ b/spm_non_sphericity/input/sub08_con0001.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a5a2099e346abc067e8899b32dfe6e921bfc26cfba5d2d92214098644e07faaa
+size 2371932

--- a/spm_non_sphericity/input/sub08_con0005.nii
+++ b/spm_non_sphericity/input/sub08_con0005.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63b562f9ddd129299e7bcce41014cdfe7afa601457ad2926e2f66265f1fe1823
+size 2371932

--- a/spm_non_sphericity/input/sub08_con0009.nii
+++ b/spm_non_sphericity/input/sub08_con0009.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b07b9dc256e6c6d0785f95dd48561a850a3e13007311c03b1b0258823387f0d6
+size 2371932

--- a/spm_non_sphericity/input/sub09_con0001.nii
+++ b/spm_non_sphericity/input/sub09_con0001.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e60543cab91a7905688c2dbdd22394f5e9e28aac0d9a5d98697d81c88c07a44b
+size 2371932

--- a/spm_non_sphericity/input/sub09_con0005.nii
+++ b/spm_non_sphericity/input/sub09_con0005.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea6517a27d8bf872d8c20720325cacea1dbfb5b073832b52cfefba27571d5926
+size 2371932

--- a/spm_non_sphericity/input/sub09_con0009.nii
+++ b/spm_non_sphericity/input/sub09_con0009.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:980666ec023b62a863df1eeca1b64332c6e426d3d95d651cb51face6dcde4190
+size 2371932

--- a/spm_non_sphericity/input/sub10_con0001.nii
+++ b/spm_non_sphericity/input/sub10_con0001.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb3379829a753f241a50d9a9e08360d03575de6c9b1e7559d7d5a0faa6676a1a
+size 2371932

--- a/spm_non_sphericity/input/sub10_con0005.nii
+++ b/spm_non_sphericity/input/sub10_con0005.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e119632c34868037662728fbd77f4f6c75c0eb330a1ebdd3e89fc8121de656d6
+size 2371932

--- a/spm_non_sphericity/input/sub10_con0009.nii
+++ b/spm_non_sphericity/input/sub10_con0009.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67d91fc328d38fd9de92c94033ede0da82459758f7bc8810e67d91d54d1eda04
+size 2371932

--- a/spm_non_sphericity/input/sub11_con0001.nii
+++ b/spm_non_sphericity/input/sub11_con0001.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e859d4e4e704458238c28ba96f1943bebd4477f7dd22e0576d6dbc66141c455
+size 2371932

--- a/spm_non_sphericity/input/sub11_con0005.nii
+++ b/spm_non_sphericity/input/sub11_con0005.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f6ae88c5b5cfa41e185e5c14571cb5fc71e82840f7f18aefbcde34cee492ab0b
+size 2371932

--- a/spm_non_sphericity/input/sub11_con0009.nii
+++ b/spm_non_sphericity/input/sub11_con0009.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5099035c5b43e9ecf45ff8f414c50ea684015dc351d9a6b36b04340c6e378fc6
+size 2371932

--- a/spm_non_sphericity/input/sub12_con0001.nii
+++ b/spm_non_sphericity/input/sub12_con0001.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1bd8fed456a66d6afa19ce02d95d3f2142e1fb3e27aa844b0534237b12b053c
+size 2371932

--- a/spm_non_sphericity/input/sub12_con0005.nii
+++ b/spm_non_sphericity/input/sub12_con0005.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:474fe6c80e7436879d3bad3f87567d53e2d8683e68db7b9c9ff0be7011e1d551
+size 2371932

--- a/spm_non_sphericity/input/sub12_con0009.nii
+++ b/spm_non_sphericity/input/sub12_con0009.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57640816c08fe4eb5542441ea09ca17f655f41dd63702499d67bfe745267e532
+size 2371932

--- a/spm_non_sphericity/input/sub13_con0001.nii
+++ b/spm_non_sphericity/input/sub13_con0001.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:839ac919ad8b2b5138e88c7b1193b1871844fe90c7d844070cb4a46fe47feb2f
+size 2371932

--- a/spm_non_sphericity/input/sub13_con0005.nii
+++ b/spm_non_sphericity/input/sub13_con0005.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77205b8a413ccb4da29b4c4d4cde3957e3bc1585a071659fc8eeeb572ae8ff68
+size 2371932

--- a/spm_non_sphericity/input/sub13_con0009.nii
+++ b/spm_non_sphericity/input/sub13_con0009.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5142232093e82d7ad6fd27794e447e745d3fefea2418c557c6a527a58f8155f
+size 2371932

--- a/spm_non_sphericity/input/sub14_con0001.nii
+++ b/spm_non_sphericity/input/sub14_con0001.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:185a0cbd9dd78be1acae9c735a740ac7a2b9743bd97a21cf351d81ce72a048af
+size 2371932

--- a/spm_non_sphericity/input/sub14_con0005.nii
+++ b/spm_non_sphericity/input/sub14_con0005.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55929bf0498f91f21274a89af46734a897c69096469edc834bdbba19588efb98
+size 2371932

--- a/spm_non_sphericity/input/sub14_con0009.nii
+++ b/spm_non_sphericity/input/sub14_con0009.nii
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c06b3acbd09cdaad52b49e917f1aaba31ff82183dd557700885de09d9304fdba
+size 2371932


### PR DESCRIPTION
This PR creates an input sub-directory within the spm_non_sphericity example containing the HRF files required as inputs for the spm non-sphericity example. The batch.m script has been amended to use the files in the input sub-directory rather than from an external directory. 
