### PR TITLE
Cluster coordinate update

### DIFF
--- a/_ground_truth/1.1.0/fsl_full_example001/nidm.ttl
+++ b/_ground_truth/1.1.0/fsl_full_example001/nidm.ttl
@@ -318,25 +318,25 @@ niiri:coordinate_0004_6 a prov:Entity , prov:Location , nidm_Coordinate: ;
 
 niiri:COG_coordinate_0001 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0001" ;
-	nidm_coordinateVector: "[ -4.39, 28.6, 55.9 ]"^^xsd:string ;
+	nidm_coordinateVector: "[-4.5, 28.7, 56.0]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 32.3, 39.2, 31.0 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0002 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0002" ;
-	nidm_coordinateVector: "[ -56.4, -41.4, 16.5 ]"^^xsd:string ;
+	nidm_coordinateVector: "[-56.3, -41.3, 16.5]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 47.1, 19.2, 19.7 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0003  a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0003" ;
-	nidm_coordinateVector: "[-43.5, 32.6, 31.1]"^^xsd:string ;
+	nidm_coordinateVector: "[-43.4, 32.5, 31.1]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 43.4, 40.3, 23.9 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0004   a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0004" ;
-	nidm_coordinateVector: "[-10.5, -56.9, -3.41]"^^xsd:string ;
+	nidm_coordinateVector: "[-10.5, -57.1, -3.5]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 34.0, 14.7, 14.0 ]"^^xsd:string .
 
 

--- a/_ground_truth/1.1.0/fsl_full_example001/nidm.ttl
+++ b/_ground_truth/1.1.0/fsl_full_example001/nidm.ttl
@@ -318,25 +318,25 @@ niiri:coordinate_0004_6 a prov:Entity , prov:Location , nidm_Coordinate: ;
 
 niiri:COG_coordinate_0001 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0001" ;
-	nidm_coordinateVector: "[-4.5, 28.7, 56.0]"^^xsd:string ;
+	nidm_coordinateVector: "[ -4.39, 28.6, 55.9 ]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 32.3, 39.2, 31.0 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0002 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0002" ;
-	nidm_coordinateVector: "[-56.3, -41.3, 16.5]"^^xsd:string ;
+	nidm_coordinateVector: "[ -56.4, -41.4, 16.5 ]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 47.1, 19.2, 19.7 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0003  a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0003" ;
-	nidm_coordinateVector: "[-43.4, 32.5, 31.1]"^^xsd:string ;
+	nidm_coordinateVector: "[-43.5, 32.6, 31.1]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 43.4, 40.3, 23.9 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0004   a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0004" ;
-	nidm_coordinateVector: "[-10.5, -57.1, -3.5]"^^xsd:string ;
+	nidm_coordinateVector: "[-10.5, -56.9, -3.41]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 34.0, 14.7, 14.0 ]"^^xsd:string .
 
 

--- a/_ground_truth/1.1.0/fsl_full_example001/nidm.ttl
+++ b/_ground_truth/1.1.0/fsl_full_example001/nidm.ttl
@@ -318,25 +318,25 @@ niiri:coordinate_0004_6 a prov:Entity , prov:Location , nidm_Coordinate: ;
 
 niiri:COG_coordinate_0001 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0001" ;
-	nidm_coordinateVector: "[ -4.39, 28.6, 55.9 ]"^^xsd:string ;
+	nidm_coordinateVector: "[-4.55, 28.7, 56.0]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 32.3, 39.2, 31.0 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0002 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0002" ;
-	nidm_coordinateVector: "[ -56.4, -41.4, 16.5 ]"^^xsd:string ;
+	nidm_coordinateVector: "[-56.35, -41.3, 16.45]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 47.1, 19.2, 19.7 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0003  a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0003" ;
-	nidm_coordinateVector: "[-43.5, 32.6, 31.1]"^^xsd:string ;
+	nidm_coordinateVector: "[-43.4, 32.55, 31.15]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 43.4, 40.3, 23.9 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0004   a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0004" ;
-	nidm_coordinateVector: "[-10.5, -56.9, -3.41]"^^xsd:string ;
+	nidm_coordinateVector: "[-10.5, -57.05, -3.5]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 34.0, 14.7, 14.0 ]"^^xsd:string .
 
 

--- a/_ground_truth/1.1.0/fsl_full_example001/nidm.ttl
+++ b/_ground_truth/1.1.0/fsl_full_example001/nidm.ttl
@@ -318,25 +318,25 @@ niiri:coordinate_0004_6 a prov:Entity , prov:Location , nidm_Coordinate: ;
 
 niiri:COG_coordinate_0001 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0001" ;
-	nidm_coordinateVector: "[-4.55, 28.7, 56.0]"^^xsd:string ;
+	nidm_coordinateVector: "[-4.5, 28.7, 56.0]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 32.3, 39.2, 31.0 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0002 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0002" ;
-	nidm_coordinateVector: "[-56.35, -41.3, 16.45]"^^xsd:string ;
+	nidm_coordinateVector: "[-56.3, -41.3, 16.5]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 47.1, 19.2, 19.7 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0003  a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0003" ;
-	nidm_coordinateVector: "[-43.4, 32.55, 31.15]"^^xsd:string ;
+	nidm_coordinateVector: "[-43.4, 32.5, 31.1]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 43.4, 40.3, 23.9 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0004   a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0004" ;
-	nidm_coordinateVector: "[-10.5, -57.05, -3.5]"^^xsd:string ;
+	nidm_coordinateVector: "[-10.5, -57.1, -3.5]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 34.0, 14.7, 14.0 ]"^^xsd:string .
 
 

--- a/_ground_truth/1.1.0/fsl_full_example001/nidm.ttl
+++ b/_ground_truth/1.1.0/fsl_full_example001/nidm.ttl
@@ -318,7 +318,7 @@ niiri:coordinate_0004_6 a prov:Entity , prov:Location , nidm_Coordinate: ;
 
 niiri:COG_coordinate_0001 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0001" ;
-	nidm_coordinateVector: "[-4.5, 28.7, 56.0]"^^xsd:string ;
+	nidm_coordinateVector: "[-4.55, 28.7, 56.0]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 32.3, 39.2, 31.0 ]"^^xsd:string .
 
 

--- a/_ground_truth/1.2.0/fsl_full_example001/nidm.ttl
+++ b/_ground_truth/1.2.0/fsl_full_example001/nidm.ttl
@@ -325,25 +325,25 @@ niiri:coordinate_0004_6 a prov:Entity , prov:Location , nidm_Coordinate: ;
 
 niiri:COG_coordinate_0001 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0001" ;
-	nidm_coordinateVector: "[-4.55, 28.7, 56.0]"^^xsd:string ;
+	nidm_coordinateVector: "[-4.5, 28.7, 56.0]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 32.3, 39.2, 31.0 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0002 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0002" ;
-	nidm_coordinateVector: "[-56.35, -41.3, 16.45]"^^xsd:string ;
+	nidm_coordinateVector: "[-56.3, -41.3, 16.5]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 47.1, 19.2, 19.7 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0003  a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0003" ;
-	nidm_coordinateVector: "[-43.4, 32.55, 31.15]"^^xsd:string ;
+	nidm_coordinateVector: "[-43.4, 32.5, 31.1]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 43.4, 40.3, 23.9 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0004   a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0004" ;
-	nidm_coordinateVector: "[-10.5, -57.05, -3.5]"^^xsd:string ;
+	nidm_coordinateVector: "[-10.5, -57.1, -3.5]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 34.0, 14.7, 14.0 ]"^^xsd:string .
 
 

--- a/_ground_truth/1.2.0/fsl_full_example001/nidm.ttl
+++ b/_ground_truth/1.2.0/fsl_full_example001/nidm.ttl
@@ -325,7 +325,7 @@ niiri:coordinate_0004_6 a prov:Entity , prov:Location , nidm_Coordinate: ;
 
 niiri:COG_coordinate_0001 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0001" ;
-	nidm_coordinateVector: "[-4.5, 28.7, 56.0]"^^xsd:string ;
+	nidm_coordinateVector: "[-4.55, 28.7, 56.0]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 32.3, 39.2, 31.0 ]"^^xsd:string .
 
 

--- a/_ground_truth/1.2.0/fsl_full_example001/nidm.ttl
+++ b/_ground_truth/1.2.0/fsl_full_example001/nidm.ttl
@@ -325,25 +325,25 @@ niiri:coordinate_0004_6 a prov:Entity , prov:Location , nidm_Coordinate: ;
 
 niiri:COG_coordinate_0001 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0001" ;
-	nidm_coordinateVector: "[ -4.39, 28.6, 55.9 ]"^^xsd:string ;
+	nidm_coordinateVector: "[-4.5, 28.7, 56.0]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 32.3, 39.2, 31.0 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0002 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0002" ;
-	nidm_coordinateVector: "[ -56.4, -41.4, 16.5 ]"^^xsd:string ;
+	nidm_coordinateVector: "[-56.3, -41.3, 16.5]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 47.1, 19.2, 19.7 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0003  a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0003" ;
-	nidm_coordinateVector: "[-43.5, 32.6, 31.1]"^^xsd:string ;
+	nidm_coordinateVector: "[-43.4, 32.5, 31.1]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 43.4, 40.3, 23.9 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0004   a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0004" ;
-	nidm_coordinateVector: "[-10.5, -56.9, -3.41]"^^xsd:string ;
+	nidm_coordinateVector: "[-10.5, -57.1, -3.5]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 34.0, 14.7, 14.0 ]"^^xsd:string .
 
 

--- a/_ground_truth/1.2.0/fsl_full_example001/nidm.ttl
+++ b/_ground_truth/1.2.0/fsl_full_example001/nidm.ttl
@@ -325,25 +325,25 @@ niiri:coordinate_0004_6 a prov:Entity , prov:Location , nidm_Coordinate: ;
 
 niiri:COG_coordinate_0001 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0001" ;
-	nidm_coordinateVector: "[ -4.39, 28.6, 55.9 ]"^^xsd:string ;
+	nidm_coordinateVector: "[-4.55, 28.7, 56.0]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 32.3, 39.2, 31.0 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0002 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0002" ;
-	nidm_coordinateVector: "[ -56.4, -41.4, 16.5 ]"^^xsd:string ;
+	nidm_coordinateVector: "[-56.35, -41.3, 16.45]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 47.1, 19.2, 19.7 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0003  a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0003" ;
-	nidm_coordinateVector: "[-43.5, 32.6, 31.1]"^^xsd:string ;
+	nidm_coordinateVector: "[-43.4, 32.55, 31.15]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 43.4, 40.3, 23.9 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0004   a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0004" ;
-	nidm_coordinateVector: "[-10.5, -56.9, -3.41]"^^xsd:string ;
+	nidm_coordinateVector: "[-10.5, -57.05, -3.5]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 34.0, 14.7, 14.0 ]"^^xsd:string .
 
 

--- a/_ground_truth/1.2.0/fsl_full_example001/nidm.ttl
+++ b/_ground_truth/1.2.0/fsl_full_example001/nidm.ttl
@@ -325,25 +325,25 @@ niiri:coordinate_0004_6 a prov:Entity , prov:Location , nidm_Coordinate: ;
 
 niiri:COG_coordinate_0001 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0001" ;
-	nidm_coordinateVector: "[-4.5, 28.7, 56.0]"^^xsd:string ;
+	nidm_coordinateVector: "[ -4.39, 28.6, 55.9 ]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 32.3, 39.2, 31.0 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0002 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0002" ;
-	nidm_coordinateVector: "[-56.3, -41.3, 16.5]"^^xsd:string ;
+	nidm_coordinateVector: "[ -56.4, -41.4, 16.5 ]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 47.1, 19.2, 19.7 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0003  a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0003" ;
-	nidm_coordinateVector: "[-43.4, 32.5, 31.1]"^^xsd:string ;
+	nidm_coordinateVector: "[-43.5, 32.6, 31.1]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 43.4, 40.3, 23.9 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0004   a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0004" ;
-	nidm_coordinateVector: "[-10.5, -57.1, -3.5]"^^xsd:string ;
+	nidm_coordinateVector: "[-10.5, -56.9, -3.41]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 34.0, 14.7, 14.0 ]"^^xsd:string .
 
 

--- a/_ground_truth/1.3.0/fsl_full_example001/nidm.ttl
+++ b/_ground_truth/1.3.0/fsl_full_example001/nidm.ttl
@@ -340,25 +340,25 @@ niiri:coordinate_0004_6 a prov:Entity , prov:Location , nidm_Coordinate: ;
 
 niiri:COG_coordinate_0001 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0001"^^xsd:string; ;
-	nidm_coordinateVector: "[ -4.39, 28.6, 55.9 ]"^^xsd:string ;
+	nidm_coordinateVector: "[-4.55, 28.7, 56.0]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 32.3, 39.2, 31.0 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0002 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0002"^^xsd:string; ;
-	nidm_coordinateVector: "[ -56.4, -41.4, 16.5 ]"^^xsd:string ;
+	nidm_coordinateVector: "[-56.35, -41.3, 16.45]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 47.1, 19.2, 19.7 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0003  a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0003"^^xsd:string; ;
-	nidm_coordinateVector: "[-43.5, 32.6, 31.1]"^^xsd:string ;
+	nidm_coordinateVector: "[-43.4, 32.55, 31.15]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 43.4, 40.3, 23.9 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0004   a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0004"^^xsd:string; ;
-	nidm_coordinateVector: "[-10.5, -56.9, -3.41]"^^xsd:string ;
+	nidm_coordinateVector: "[-10.5, -57.05, -3.5]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 34.0, 14.7, 14.0 ]"^^xsd:string .
 
 

--- a/_ground_truth/1.3.0/fsl_full_example001/nidm.ttl
+++ b/_ground_truth/1.3.0/fsl_full_example001/nidm.ttl
@@ -340,25 +340,25 @@ niiri:coordinate_0004_6 a prov:Entity , prov:Location , nidm_Coordinate: ;
 
 niiri:COG_coordinate_0001 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0001"^^xsd:string; ;
-	nidm_coordinateVector: "[ -4.39, 28.6, 55.9 ]"^^xsd:string ;
+	nidm_coordinateVector: "[-4.5, 28.7, 56.0]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 32.3, 39.2, 31.0 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0002 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0002"^^xsd:string; ;
-	nidm_coordinateVector: "[ -56.4, -41.4, 16.5 ]"^^xsd:string ;
+	nidm_coordinateVector: "[-56.3, -41.3, 16.5]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 47.1, 19.2, 19.7 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0003  a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0003"^^xsd:string; ;
-	nidm_coordinateVector: "[-43.5, 32.6, 31.1]"^^xsd:string ;
+	nidm_coordinateVector: "[-43.4, 32.5, 31.1]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 43.4, 40.3, 23.9 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0004   a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0004"^^xsd:string; ;
-	nidm_coordinateVector: "[-10.5, -56.9, -3.41]"^^xsd:string ;
+	nidm_coordinateVector: "[-10.5, -57.1, -3.5]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 34.0, 14.7, 14.0 ]"^^xsd:string .
 
 

--- a/_ground_truth/1.3.0/fsl_full_example001/nidm.ttl
+++ b/_ground_truth/1.3.0/fsl_full_example001/nidm.ttl
@@ -340,25 +340,25 @@ niiri:coordinate_0004_6 a prov:Entity , prov:Location , nidm_Coordinate: ;
 
 niiri:COG_coordinate_0001 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0001"^^xsd:string; ;
-	nidm_coordinateVector: "[-4.5, 28.7, 56.0]"^^xsd:string ;
+	nidm_coordinateVector: "[ -4.39, 28.6, 55.9 ]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 32.3, 39.2, 31.0 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0002 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0002"^^xsd:string; ;
-	nidm_coordinateVector: "[-56.3, -41.3, 16.5]"^^xsd:string ;
+	nidm_coordinateVector: "[ -56.4, -41.4, 16.5 ]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 47.1, 19.2, 19.7 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0003  a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0003"^^xsd:string; ;
-	nidm_coordinateVector: "[-43.4, 32.5, 31.1]"^^xsd:string ;
+	nidm_coordinateVector: "[-43.5, 32.6, 31.1]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 43.4, 40.3, 23.9 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0004   a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0004"^^xsd:string; ;
-	nidm_coordinateVector: "[-10.5, -57.1, -3.5]"^^xsd:string ;
+	nidm_coordinateVector: "[-10.5, -56.9, -3.41]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 34.0, 14.7, 14.0 ]"^^xsd:string .
 
 

--- a/_ground_truth/1.3.0/fsl_full_example001/nidm.ttl
+++ b/_ground_truth/1.3.0/fsl_full_example001/nidm.ttl
@@ -340,7 +340,7 @@ niiri:coordinate_0004_6 a prov:Entity , prov:Location , nidm_Coordinate: ;
 
 niiri:COG_coordinate_0001 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0001"^^xsd:string; ;
-	nidm_coordinateVector: "[-4.5, 28.7, 56.0]"^^xsd:string ;
+	nidm_coordinateVector: "[-4.55, 28.7, 56.0]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 32.3, 39.2, 31.0 ]"^^xsd:string .
 
 

--- a/_ground_truth/1.3.0/fsl_full_example001/nidm.ttl
+++ b/_ground_truth/1.3.0/fsl_full_example001/nidm.ttl
@@ -346,9 +346,7 @@ niiri:COG_coordinate_0001 a prov:Entity , prov:Location , nidm_Coordinate: ;
 
 niiri:COG_coordinate_0002 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0002"^^xsd:string; ;
-	nidm_coordinateVector: "[-56.3, -41.3, 16.5]
-
-	"^^xsd:string ;
+	nidm_coordinateVector: "[-56.3, -41.3, 16.5]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 47.1, 19.2, 19.7 ]"^^xsd:string .
 
 

--- a/_ground_truth/1.3.0/fsl_full_example001/nidm.ttl
+++ b/_ground_truth/1.3.0/fsl_full_example001/nidm.ttl
@@ -340,25 +340,27 @@ niiri:coordinate_0004_6 a prov:Entity , prov:Location , nidm_Coordinate: ;
 
 niiri:COG_coordinate_0001 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0001"^^xsd:string; ;
-	nidm_coordinateVector: "[-4.55, 28.7, 56.0]"^^xsd:string ;
+	nidm_coordinateVector: "[-4.5, 28.7, 56.0]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 32.3, 39.2, 31.0 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0002 a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0002"^^xsd:string; ;
-	nidm_coordinateVector: "[-56.35, -41.3, 16.45]"^^xsd:string ;
+	nidm_coordinateVector: "[-56.3, -41.3, 16.5]
+
+	"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 47.1, 19.2, 19.7 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0003  a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0003"^^xsd:string; ;
-	nidm_coordinateVector: "[-43.4, 32.55, 31.15]"^^xsd:string ;
+	nidm_coordinateVector: "[-43.4, 32.5, 31.1]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 43.4, 40.3, 23.9 ]"^^xsd:string .
 
 
 niiri:COG_coordinate_0004   a prov:Entity , prov:Location , nidm_Coordinate: ;
 	rdfs:label "Coordinate 0004"^^xsd:string; ;
-	nidm_coordinateVector: "[-10.5, -57.05, -3.5]"^^xsd:string ;
+	nidm_coordinateVector: "[-10.5, -57.1, -3.5]"^^xsd:string ;
 	nidm_coordinateVectorInVoxels: "[ 34.0, 14.7, 14.0 ]"^^xsd:string .
 
 


### PR DESCRIPTION
This PR updates the cluster xyz locations to match what is output by PR 135 on nidmresults-fsl.

This has been done as they were previously calculated by fsl's cluster function and are now calculated by python functions in the NIDM-Results fsl exporter. Whilst these two functions output approximately the same coordinates due to rounding errors the tests on nidmresults-fsl currently fail.